### PR TITLE
fix: update quotes on table name to back ticks

### DIFF
--- a/src/utils/getLastMigrationState.ts
+++ b/src/utils/getLastMigrationState.ts
@@ -9,7 +9,7 @@ import {
 
 export default async function getLastMigrationState(sequelize: Sequelize) {
   const [lastExecutedMigration] = await sequelize.query<SequelizeMigrations>(
-    'SELECT name FROM "SequelizeMeta" ORDER BY name desc limit 1',
+    'SELECT name FROM `SequelizeMeta` ORDER BY name desc limit 1',
     { type: QueryTypes.SELECT }
   )
 
@@ -19,7 +19,7 @@ export default async function getLastMigrationState(sequelize: Sequelize) {
       : -1
 
   const [lastMigration] = await sequelize.query<SequelizeMigrationsMeta>(
-    `SELECT state FROM "SequelizeMigrationsMeta" where revision = '${lastRevision}'`,
+    "SELECT state FROM `SequelizeMigrationsMeta` where revision = '${lastRevision}'",
     { type: QueryTypes.SELECT }
   )
 


### PR DESCRIPTION
Fix: Quires to get the last stats from the database were using the double quotes over the table name("SequelizeMigrationsMeta"), that isn't the acceptable behavior from the database engine, please look into the proposed changes. TY