### PR TITLE
fix: infinite loop in reverseSequelizeColType

### DIFF
--- a/src/utils/reverseSequelizeColType.ts
+++ b/src/utils/reverseSequelizeColType.ts
@@ -117,14 +117,14 @@ export default function reverseSequelizeColType(
 
   // ARRAY ( PostgreSQL only )
   if (attrType.constructor.name === "ARRAY") {
-    const innerType = reverseSequelizeColType(sequelize, attrType);
+    const innerType = reverseSequelizeColType(sequelize, attrType.type);
 
     return `${prefix}ARRAY(${innerType})`;
   }
 
   // RANGE ( PostgreSQL only )
   if (attrType.constructor.name === "RANGE") {
-    const innerType = reverseSequelizeColType(sequelize, attrType);
+    const innerType = reverseSequelizeColType(sequelize, attrType.type);
 
     return `${prefix}RANGE(${innerType})`;
   }


### PR DESCRIPTION
Fixes infinite loop in `reverseSequelizeColType` when using ARRAY and RANGE types like that:

```ts
  @Column(DataType.ARRAY(DataType.STRING))
  dataFormats: ExportDataFormat[];
```